### PR TITLE
feat: add i18n support with ngx-translate (placeholders for en, de, fr)

### DIFF
--- a/prueba_Angular/package-lock.json
+++ b/prueba_Angular/package-lock.json
@@ -18,6 +18,8 @@
         "@angular/platform-browser": "^19.1.0",
         "@angular/platform-browser-dynamic": "^19.1.0",
         "@angular/router": "^19.1.0",
+        "@ngx-translate/core": "^16.0.4",
+        "@ngx-translate/http-loader": "^16.0.1",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.15.0"
@@ -4179,6 +4181,32 @@
         "@angular/compiler-cli": "^19.0.0",
         "typescript": ">=5.5 <5.8",
         "webpack": "^5.54.0"
+      }
+    },
+    "node_modules/@ngx-translate/core": {
+      "version": "16.0.4",
+      "resolved": "https://registry.npmjs.org/@ngx-translate/core/-/core-16.0.4.tgz",
+      "integrity": "sha512-s8llTL2SJvROhqttxvEs7Cg+6qSf4kvZPFYO+cTOY1d8DWTjlutRkWAleZcPPoeX927Dm7ALfL07G7oYDJ7z6w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": ">=16",
+        "@angular/core": ">=16"
+      }
+    },
+    "node_modules/@ngx-translate/http-loader": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@ngx-translate/http-loader/-/http-loader-16.0.1.tgz",
+      "integrity": "sha512-xJEOUpvs6Zfc8G4cmQmegFOEpfYSoplTHHoisPNrATXjRBjpaKsBaPOXlZsuFUW2XV00s16gIyI4+9z1XkO5bw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": ">=16",
+        "@angular/core": ">=16"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/prueba_Angular/package.json
+++ b/prueba_Angular/package.json
@@ -23,6 +23,8 @@
     "@angular/platform-browser": "^19.1.0",
     "@angular/platform-browser-dynamic": "^19.1.0",
     "@angular/router": "^19.1.0",
+    "@ngx-translate/core": "^16.0.4",
+    "@ngx-translate/http-loader": "^16.0.1",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"

--- a/prueba_Angular/src/app/app.config.ts
+++ b/prueba_Angular/src/app/app.config.ts
@@ -1,12 +1,20 @@
-import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { ApplicationConfig, provideZoneChangeDetection, importProvidersFrom } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { provideHttpClient } from '@angular/common/http';
-import { importProvidersFrom } from '@angular/core';
+
+import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
+import { HttpClient } from '@angular/common/http';
+import { TranslateHttpLoader } from '@ngx-translate/http-loader';
 
 import { routes } from './app.routes';
 
 import { MatButtonModule } from '@angular/material/button';
+
+// Creamos el loader para las traducciones
+export function HttpLoaderFactory(http: HttpClient) {
+  return new TranslateHttpLoader(http, './assets/i18n/', '.json');
+}
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -14,6 +22,19 @@ export const appConfig: ApplicationConfig = {
     provideRouter(routes),
     provideAnimations(),
     provideHttpClient(),
-    importProvidersFrom(MatButtonModule)
+    importProvidersFrom(
+      MatButtonModule,
+
+      // Importamos el modulo de traducciones con el loader creado
+      TranslateModule.forRoot({
+        loader: {
+          provide: TranslateLoader,
+          useFactory: HttpLoaderFactory,
+          deps: [HttpClient]
+        },
+        defaultLanguage: 'es',
+        useDefaultLang: true
+      })
+    )
   ]
 };

--- a/prueba_Angular/src/assets/de.json
+++ b/prueba_Angular/src/assets/de.json
@@ -1,0 +1,3 @@
+{
+    "TODO": "Traducciones para la app en este idioma."
+}

--- a/prueba_Angular/src/assets/en.json
+++ b/prueba_Angular/src/assets/en.json
@@ -1,0 +1,3 @@
+{
+    "TODO": "Traducciones para la app en este idioma."
+}  

--- a/prueba_Angular/src/assets/es.json
+++ b/prueba_Angular/src/assets/es.json
@@ -1,0 +1,16 @@
+{
+    "APP": {
+      "TITLE": "Mi Aplicación Angular",
+      "WELCOME": "¡Bienvenido a la aplicación de prueba!"
+    },
+    "SONGS": {
+      "TITLE": "Canciones",
+      "DESCRIPTION": "Lista de canciones disponibles"
+    },
+    "BUTTONS": {
+      "ADD": "Añadir",
+      "DELETE": "Eliminar",
+      "SAVE": "Guardar"
+    }
+  }
+  

--- a/prueba_Angular/src/assets/fr.json
+++ b/prueba_Angular/src/assets/fr.json
@@ -1,0 +1,3 @@
+{
+    "TODO": "Traducciones para la app en este idioma."
+}


### PR DESCRIPTION
- Se instaló @ngx-translate/core y @ngx-translate/http-loader
- Se configuró el TranslateModule en app.config.ts con defaultLanguage = 'es'
- Se creó el archivo es.json con algunas claves mínimas
- Se añadieron archivos de idioma en.json, de.json, fr.json con placeholders (TODO)